### PR TITLE
Avoid root-level label in favor of top-level label

### DIFF
--- a/draft-ietf-dnsop-alt-tld.xml
+++ b/draft-ietf-dnsop-alt-tld.xml
@@ -74,13 +74,13 @@
       <t>Many Internet protocols need to name entities. Names that look
       like DNS names (a series of labels separated with dots) have become
       common, even in systems that are not part of the global DNS administered
-      by IANA. This document reserves the root-level label "alt" (short for
+      by IANA. This document reserves the top-level label "alt" (short for
       "alternative") as a special-use domain name (<xref target="RFC6761"/>). This
-      root-level label can be used as the final (rightmost) label to signify
+      top-level label can be used as the final (rightmost) label to signify
       that the name is not rooted in the DNS, and that it should not be
       resolved using the DNS protocol.</t>
       
-      <t>Throughout the rest of this document, the root-level "alt" label is shown
+      <t>Throughout the rest of this document, the top-level "alt" label is shown
       as ".alt" to match the common presentation form of DNS names.</t>
 
       <t>The techniques in this document are primarily intended to address the
@@ -113,7 +113,7 @@
             name in the position of a TLD, but which is not registered in the
             global DNS. This term is not intended to be pejorative.</t>
 
-            <t>TLD: The last visible label in either a fully-qualified domain
+            <t>TLD, top-level label: The last visible label in either a fully-qualified domain
             name or a name that is qualified relative to the root.</t>
           </list></t>
       </section>


### PR DESCRIPTION
The text so far is inconsistent in the use of top-level vs. root-level:

- So far, it said that the "alt" label is a root-level label, final and rightmost. The sounds like it would be a non-empty alternative to the (empty) DNS root label.
- OTOH, the text says that "alt" is a TLD, and defines a TLD to be "[t]he last visible label in [...] a name that is qualified relative to the root". In other words, that's a one-below-the-root label.

The PR replaces "root-level label" with "top-level label" when referring to the "alt" label, and adds the "top-level label" term alongside the "TLD" term in the Terminology section. (The term "root-level label" so far was not defined.)